### PR TITLE
implement visitChildren method in _RenderLayoutBuilder

### DIFF
--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -333,6 +333,13 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
       context.paintChild(child!, offset);
     }
   }
+  
+  @override
+  void visitChildren(RenderObjectVisitor visitor) {
+    if (child case child?) {
+      visitor(case);
+    }
+  }
 
   bool _debugThrowIfNotCheckingIntrinsics() {
     assert(() {

--- a/packages/flutter/lib/src/widgets/layout_builder.dart
+++ b/packages/flutter/lib/src/widgets/layout_builder.dart
@@ -336,8 +336,8 @@ class _RenderLayoutBuilder extends RenderBox with RenderObjectWithChildMixin<Ren
   
   @override
   void visitChildren(RenderObjectVisitor visitor) {
-    if (child case child?) {
-      visitor(case);
+    if (child case final RenderObject child) {
+      visitor(child);
     }
   }
 


### PR DESCRIPTION
Implement the method `visitChildren` in `_RenderLayoutBuilder`.

Fixes #134522.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
